### PR TITLE
Make directories when not exist

### DIFF
--- a/lib/gcr.rb
+++ b/lib/gcr.rb
@@ -29,6 +29,8 @@ module GCR
   # Returns nothing.
   def cassette_dir=(path)
     raise RunningError, "cannot configure GCR within #with_cassette block" if @running
+
+    FileUtils.mkdir_p(path) unless File.exist?(path)
     @cassette_dir = path
   end
 

--- a/lib/gcr/cassette.rb
+++ b/lib/gcr/cassette.rb
@@ -20,6 +20,7 @@ class GCR::Cassette
   def initialize(name)
     @path = File.join(GCR.cassette_dir, "#{name}.json")
     @reqs = []
+    FileUtils.mkdir_p(File.dirname(@path))
   end
 
   # Does this cassette exist?


### PR DESCRIPTION
The GCR should create not-existed directories when persisting cassette and main `GCR.cassette_dir`.