### PR TITLE
Save empty requests option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ test "MyController#index works" do
 end
 ```
 
+## Configuration
+
+To not save empty requests (for instance when error occur), set `save_empty_requests` as `false`.
+```ruby
+GCR.save_empty_requests = false
+```
+
 ## Tests
 
 To run tests:

--- a/lib/gcr.rb
+++ b/lib/gcr.rb
@@ -22,6 +22,24 @@ module GCR
     @ignored_fields ||= []
   end
 
+  # Save cassette when requests list is empty?
+  #
+  # Returns boolean
+  def save_empty_requests=(value)
+    @save_empty_requests = value
+  end
+
+  # Save cassette when requests list is empty?
+  #
+  # Returns boolean, `true` by default
+  def save_empty_requests
+    return true if @save_empty_requests.nil?
+
+    @save_empty_requests
+  end
+
+  alias save_empty_requests? save_empty_requests
+
   # Specify where GCR should store cassettes.
   #
   # path - The String path to a directory.

--- a/lib/gcr/cassette.rb
+++ b/lib/gcr/cassette.rb
@@ -48,6 +48,8 @@ class GCR::Cassette
   #
   # Returns nothing.
   def save
+    return if reqs.empty? && !GCR.save_empty_requests?
+
     File.open(@path, "w") do |f|
       f.write(JSON.pretty_generate(
         "version" => VERSION,


### PR DESCRIPTION
When GRPC error occurs GCR can not persist requests to file. This is a workaround to not save empty requests in this case by setting `GCR.save_empty_requests = false` option.